### PR TITLE
fix(workflow): correct Slack webhook conditional check

### DIFF
--- a/.github/workflows/jirasync.yml
+++ b/.github/workflows/jirasync.yml
@@ -160,19 +160,26 @@ jobs:
           if-no-files-found: ignore
 
       - name: Notify on failure
-        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
-            -H 'Content-Type: application/json' \
-            -d '{
-              "text": "❌ JiraSync workflow failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*JiraSync Failed*\n\nWorkflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            curl -X POST "$SLACK_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d '{
+                "text": "❌ JiraSync workflow failed",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*JiraSync Failed*\n\nWorkflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+                    }
                   }
-                }
-              ]
-            }'
+                ]
+              }'
+            echo "Slack notification sent"
+          else
+            echo "Slack webhook not configured, skipping notification"
+          fi


### PR DESCRIPTION
Fix GitHub Actions syntax error where secrets can't be compared directly in conditional expressions.

- Move secret check to environment variable
- Use bash conditional inside run script
- Add helpful log messages for both cases