### PR TITLE
fix(github): detect merged PRs using MergedAt field

### DIFF
--- a/internal/github/pr_state.go
+++ b/internal/github/pr_state.go
@@ -38,14 +38,17 @@ func (s PRState) Priority() int {
 // GetPRState determines the state of a pull request
 // Following the logic from ospctl/test/main.go
 func (c *Client) GetPRState(ctx context.Context, pr *github.PullRequest) (PRState, error) {
-	// Check if closed without merge
-	if pr.GetState() == "closed" && !pr.GetMerged() {
-		return PRStateClosed, nil
+	// Check if merged first - MergedAt is more reliable than Merged field
+	// When listing PRs, the Merged boolean field is sometimes not populated,
+	// but MergedAt timestamp is always set for merged PRs
+	if pr.MergedAt != nil && !pr.MergedAt.IsZero() {
+		return PRStateMerged, nil
 	}
 
-	// Check if merged
-	if pr.GetMerged() {
-		return PRStateMerged, nil
+	// Check if closed without merge
+	// If we reach here, MergedAt is nil/zero, so this is truly a closed (not merged) PR
+	if pr.GetState() == "closed" {
+		return PRStateClosed, nil
 	}
 
 	// Check if draft


### PR DESCRIPTION
Critical bug fix: Merged PRs were being incorrectly detected as "closed", causing tickets to transition to "In Progress" instead of "On QA".

Problem:
- pr.GetMerged() boolean is not reliably populated when listing PRs
- Merged PRs have state="closed", so they were caught by the closed check
- Example: tektoncd/pipelines-as-code#2423 detected as "closed" not "merged"

Solution:
- Check pr.MergedAt timestamp first (always set for merged PRs)
- Only treat as closed if state="closed" AND MergedAt is nil/zero
- More reliable detection using timestamp instead of boolean field

Impact:
- Merged PRs now correctly transition tickets to "On QA"
- Closed (unmerged) PRs still correctly transition to "In Progress"