### PR TITLE
feat(jirasync): track and surface skipped PR counts

### DIFF
--- a/cmd/jirasync/main.go
+++ b/cmd/jirasync/main.go
@@ -144,12 +144,16 @@ func runSync(cmd *cobra.Command, args []string) error {
 func printSummary(summary *jirasync.SyncSummary) {
 	fmt.Println("\n=== Sync Summary ===")
 	totalPRs := 0
+	totalSkipped := 0
 	totalTickets := 0
 	totalErrors := 0
 
 	for _, result := range summary.Results {
 		fmt.Printf("\n%s/%s:\n", result.Repository.Owner, result.Repository.Name)
 		fmt.Printf("  PRs processed: %d\n", result.PRsProcessed)
+		if result.PRsSkipped > 0 {
+			fmt.Printf("  PRs skipped (not in users list): %d\n", result.PRsSkipped)
+		}
 		fmt.Printf("  Tickets transitioned: %d\n", result.TicketsTransitioned)
 		if len(result.Errors) > 0 {
 			fmt.Printf("  Errors: %d\n", len(result.Errors))
@@ -159,12 +163,16 @@ func printSummary(summary *jirasync.SyncSummary) {
 		}
 
 		totalPRs += result.PRsProcessed
+		totalSkipped += result.PRsSkipped
 		totalTickets += result.TicketsTransitioned
 		totalErrors += len(result.Errors)
 	}
 
 	fmt.Printf("\nTotal:\n")
-	fmt.Printf("  PRs: %d\n", totalPRs)
+	fmt.Printf("  PRs processed: %d\n", totalPRs)
+	if totalSkipped > 0 {
+		fmt.Printf("  PRs skipped (not in users list): %d\n", totalSkipped)
+	}
 	fmt.Printf("  Tickets transitioned: %d\n", totalTickets)
 	fmt.Printf("  Tickets already in correct status: %d\n", summary.TicketsInCorrectStatus)
 	fmt.Printf("  Unlinked PRs: %d\n", summary.UnlinkedPRs)

--- a/internal/jirasync/syncer.go
+++ b/internal/jirasync/syncer.go
@@ -33,6 +33,7 @@ type Syncer struct {
 type SyncResult struct {
 	Repository          Repository
 	PRsProcessed        int
+	PRsSkipped          int
 	TicketsTransitioned int
 	Errors              []error
 }

--- a/test/jirasync/main.go
+++ b/test/jirasync/main.go
@@ -131,6 +131,7 @@ func main() {
 	})
 
 	totalPRs := 0
+	totalSkipped := 0
 	unlinkedPRs := 0
 	for _, repo := range repos {
 		fmt.Printf("\nRepository: %s/%s\n", repo.Owner, repo.Name)
@@ -143,7 +144,9 @@ func main() {
 		}
 
 		fmt.Printf("  Found %d PRs\n", len(prs))
-		totalPRs += len(prs)
+		if len(allowedUsers) > 0 {
+			fmt.Printf("  Filtering to configured users (%d total)\n", len(allowedUsers))
+		}
 
 		// Get PR states and link to tickets
 		for _, pr := range prs {
@@ -152,9 +155,11 @@ func main() {
 				author := strings.ToLower(pr.GetUser().GetLogin())
 				if !allowedUsers[author] {
 					fmt.Printf("  PR #%d by %s — skipping (not in users list)\n", pr.GetNumber(), pr.GetUser().GetLogin())
+					totalSkipped++
 					continue
 				}
 			}
+			totalPRs++
 
 			state, err := ghClient.GetPRState(ctx, pr)
 			if err != nil {
@@ -219,7 +224,10 @@ func main() {
 
 	fmt.Printf("\n=== Collection Summary ===\n")
 	fmt.Printf("Total repositories: %d\n", len(repos))
-	fmt.Printf("Total PRs collected: %d\n", totalPRs)
+	fmt.Printf("Total PRs processed: %d\n", totalPRs)
+	if totalSkipped > 0 {
+		fmt.Printf("Total PRs skipped (not in users list): %d\n", totalSkipped)
+	}
 	fmt.Printf("Unique Jira tickets: %d\n", len(globalTicketPRs))
 
 	// Count cross-repo tickets
@@ -397,7 +405,10 @@ func main() {
 	fmt.Printf("Overall Summary\n")
 	fmt.Printf("═══════════════════════════════════════════════════════════\n")
 	fmt.Printf("Total repositories: %d\n", len(repos))
-	fmt.Printf("Total PRs collected: %d\n", totalPRs)
+	fmt.Printf("Total PRs processed: %d\n", totalPRs)
+	if totalSkipped > 0 {
+		fmt.Printf("Total PRs skipped (not in users list): %d\n", totalSkipped)
+	}
 	fmt.Printf("Unique Jira tickets: %d\n", len(globalTicketPRs))
 	fmt.Printf("Tickets with cross-repo PRs: %d\n", crossRepoTickets)
 	fmt.Printf("Transitions that would be executed: %d\n", transitionsFound)


### PR DESCRIPTION
PRs filtered out by the users list are now counted separately and shown in the sync summary, making it clear how many PRs were seen versus actually processed.