### PR TITLE
feat(jirasync): add transition comment on ticket move

### DIFF
--- a/.github/workflows/jirasync.yml
+++ b/.github/workflows/jirasync.yml
@@ -108,7 +108,8 @@ jobs:
             --jira-url \"$JIRA_URL\" \
             --jira-email \"$JIRA_EMAIL\" \
             --jira-token \"$JIRA_TOKEN\" \
-            --jira-pr-field \"$JIRA_PR_FIELD\""
+            --jira-pr-field \"$JIRA_PR_FIELD\" \
+            --transition-comment"
 
           # Add since date if provided
           if [ -n "$SINCE_DATE" ]; then

--- a/cmd/jirasync/README.md
+++ b/cmd/jirasync/README.md
@@ -9,10 +9,12 @@
 ## Features
 
 - **Cross-repository support**: Monitor PRs across multiple GitHub repositories
+- **User filtering**: Only process PRs authored by a configured list of users
 - **Dynamic transition detection**: Uses Jira API to fetch available transitions (no hardcoding)
 - **Multi-step transitions**: Automatically navigates intermediate workflow states
 - **Global batching**: Handles tickets with PRs across multiple repositories
 - **Automated release notes**: Extracts or AI-generates release notes from merged PRs and updates Jira
+- **Transition comments**: Optionally adds a Jira comment on each transitioned ticket explaining why it was moved
 - **Slack integration**: Optional notifications for transitioned tickets
 - **Flexible date filtering**: Process PRs from specific dates or time ranges
 - **Terminal state protection**: Never auto-closes tickets (On QA is the furthest state)

--- a/cmd/jirasync/main.go
+++ b/cmd/jirasync/main.go
@@ -26,6 +26,7 @@ var (
 	geminiModel                 string
 	since                       string
 	slackWebhook                string
+	transitionComment           bool
 )
 
 var rootCmd = &cobra.Command{
@@ -60,6 +61,7 @@ func init() {
 	rootCmd.Flags().StringVar(&geminiModel, "gemini-model", "", "Gemini model to use (optional, defaults to gemini-3-flash-preview)")
 	rootCmd.Flags().StringVar(&since, "since", "", "Only process PRs updated since this date (format: 2006-01-02 or DD/MM/YYYY). Defaults to yesterday if not provided.")
 	rootCmd.Flags().StringVar(&slackWebhook, "slack-webhook", "", "Slack webhook URL for notifications (optional)")
+	rootCmd.Flags().BoolVar(&transitionComment, "transition-comment", false, "Add a Jira comment on each transitioned ticket explaining the reason (optional)")
 
 	rootCmd.MarkFlagRequired("config")
 	rootCmd.MarkFlagRequired("github-token")
@@ -106,6 +108,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		geminiAPIKey,
 		geminiModel,
 		sinceTime,
+		transitionComment,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create syncer: %w", err)

--- a/internal/jirasync/syncer.go
+++ b/internal/jirasync/syncer.go
@@ -27,6 +27,7 @@ type Syncer struct {
 	jiraClient                  *jira.Client
 	geminiClient                *gemini.Client
 	sinceTime                   time.Time
+	transitionComment           bool
 }
 
 // SyncResult contains the results of syncing a repository
@@ -47,7 +48,7 @@ type SyncSummary struct {
 }
 
 // NewSyncer creates a new syncer instance
-func NewSyncer(githubToken, jiraURL, jiraEmail, jiraToken, jiraPRField, jiraReleaseNotesTextField, jiraReleaseNotesTypeField, jiraReleaseNotesStatusField, geminiAPIKey, geminiModel string, sinceTime time.Time) (*Syncer, error) {
+func NewSyncer(githubToken, jiraURL, jiraEmail, jiraToken, jiraPRField, jiraReleaseNotesTextField, jiraReleaseNotesTypeField, jiraReleaseNotesStatusField, geminiAPIKey, geminiModel string, sinceTime time.Time, transitionComment bool) (*Syncer, error) {
 	jiraClient, err := jira.NewClient(jiraURL, jiraEmail, jiraToken, jiraPRField, jiraReleaseNotesTextField, jiraReleaseNotesTypeField, jiraReleaseNotesStatusField)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Jira client: %w", err)
@@ -73,6 +74,7 @@ func NewSyncer(githubToken, jiraURL, jiraEmail, jiraToken, jiraPRField, jiraRele
 		jiraClient:                  jiraClient,
 		geminiClient:                geminiClient,
 		sinceTime:                   sinceTime,
+		transitionComment:           transitionComment,
 	}, nil
 }
 
@@ -133,6 +135,7 @@ func (s *Syncer) SyncAll(ctx context.Context, repositories []Repository, users [
 				author := strings.ToLower(pr.GetUser().GetLogin())
 				if !allowedUsers[author] {
 					fmt.Printf("  PR #%d by %s — skipping (not in users list)\n", prNumber, pr.GetUser().GetLogin())
+					results[repoIdx].PRsSkipped++
 					continue
 				}
 			}
@@ -296,6 +299,25 @@ func (s *Syncer) SyncAll(ctx context.Context, repositories []Repository, users [
 					results[i].Repository.Name == mostBehind.repo.Name {
 					results[i].TicketsTransitioned++
 					break
+				}
+			}
+
+			// Add a transition comment explaining why the ticket was moved
+			if s.transitionComment {
+				comment := fmt.Sprintf(
+					"jirasync moved this ticket from '%s' to '%s' because PR #%d in %s/%s %s.\n%s",
+					info.Status,
+					targetStatus,
+					mostBehind.number,
+					mostBehind.repo.Owner,
+					mostBehind.repo.Name,
+					prStateReason(mostBehind.state),
+					mostBehind.url,
+				)
+				if err := s.jiraClient.AddComment(issueKey, comment); err != nil {
+					fmt.Printf("  ⚠ %s: failed to add transition comment: %v\n", issueKey, err)
+				} else {
+					fmt.Printf("  💬 %s: transition comment added\n", issueKey)
 				}
 			}
 
@@ -507,5 +529,27 @@ func (s *Syncer) addReleaseNotes(ctx context.Context, pr *gogithub.PullRequest, 
 				fmt.Printf("         ⓘ Jira fields already populated - skipping\n")
 			}
 		}
+	}
+}
+
+// prStateReason returns a human-readable explanation for why a PR's state triggers a Jira transition
+func prStateReason(state github.PRState) string {
+	switch state {
+	case github.PRStateMerged:
+		return "was merged"
+	case github.PRStateDraft:
+		return "is a draft"
+	case github.PRStateChangesRequested:
+		return "has changes requested"
+	case github.PRStateClosed:
+		return "was closed without merging"
+	case github.PRStateOpen:
+		return "is open and ready for review"
+	case github.PRStateReviewRequested:
+		return "has a review requested"
+	case github.PRStateApproved:
+		return "is approved"
+	default:
+		return string(state)
 	}
 }

--- a/jirasync-repos.yaml
+++ b/jirasync-repos.yaml
@@ -42,7 +42,7 @@ repositories:
     name: triggers
 
 users:
-  - abghosh
+  - ab-ghosh
   - adityavshinde
   - anithapriyanatarajan
   - ankrsinha


### PR DESCRIPTION
Adds `--transition-comment` flag that posts a plain-text Jira comment on each transitioned ticket explaining which PR caused the move and why.

Fixes #7