### PR TITLE
chore: remove pipelines-as-code from jirasync

### DIFF
--- a/jirasync-repos.yaml
+++ b/jirasync-repos.yaml
@@ -31,8 +31,6 @@ repositories:
   - owner: tektoncd
     name: pipeline
   - owner: tektoncd
-    name: pipelines-as-code
-  - owner: tektoncd
     name: plumbing
   - owner: tektoncd
     name: pruner


### PR DESCRIPTION
Disable Jira sync for the pipelines-as-code repo.