### PR TITLE
feat(jirasync): change merged PR end state to Dev Complete

### DIFF
--- a/.github/workflows/SETUP.md
+++ b/.github/workflows/SETUP.md
@@ -115,15 +115,15 @@ After a run completes:
 ```
 === Collecting PRs from openshift-pipelines/skipjira ===
   Found 5 PRs updated since 2026-04-01
-  PR #123 (merged) → target status: On QA
+  PR #123 (merged) → target status: Dev Complete
     ✓ Linked to 1 ticket(s): [SRVKP-12345]
 
 === Processing Tickets (Global Batching) ===
 Found 3 unique tickets across all repositories
 
 Processing SRVKP-12345 (current: 'Code Review')
-  PR #123 state: merged → Jira target: 'On QA'
-  ✓ Transitioned SRVKP-12345: 'Code Review' → 'On QA' (PR state: merged)
+  PR #123 state: merged → Jira target: 'Dev Complete'
+  ✓ Transitioned SRVKP-12345: 'Code Review' → 'Dev Complete' (PR state: merged)
 
 Jirasync completed - 1 tickets transitioned
 ```
@@ -134,7 +134,7 @@ You should receive a message like:
 ```
 The following Jira tickets were processed for workflow transitions.
 
-SRVKP-12345 `Code Review` → `On QA` ✅ APPLIED
+SRVKP-12345 `Code Review` → `Dev Complete` ✅ APPLIED
   • openshift-pipelines/skipjira#123: Fix bug in sync logic
 
 🤖 jirasync | 1 tickets processed • 2 already in correct status • 0 unlinked PRs

--- a/cmd/jirasync/README.md
+++ b/cmd/jirasync/README.md
@@ -17,7 +17,7 @@
 - **Transition comments**: Optionally adds a Jira comment on each transitioned ticket explaining why it was moved
 - **Slack integration**: Optional notifications for transitioned tickets
 - **Flexible date filtering**: Process PRs from specific dates or time ranges
-- **Terminal state protection**: Never auto-closes tickets (On QA is the furthest state)
+- **Terminal state protection**: Never auto-closes tickets (Dev Complete is the furthest state)
 
 ## PR State → Jira Transition Mapping
 
@@ -26,10 +26,10 @@
 | Draft / Changes Requested | In Progress |
 | Ready / Review Requested | Code Review |
 | Approved | Code Review |
-| Merged | On QA |
+| Merged | Dev Complete |
 | Closed (without merge) | In Progress |
 
-**Note:** Tickets are never automatically closed. "On QA" is the furthest automated state. Closing tickets should be done manually after QA verification.
+**Note:** Tickets are never automatically closed. "Dev Complete" is the furthest automated state. Closing tickets should be done manually after QA verification.
 
 ## Release Notes Feature
 
@@ -278,7 +278,7 @@ Example Slack message:
 ```
 The following Jira tickets were processed for workflow transitions.
 
-SRVKP-11096 `To Do` → `On QA` ✅ APPLIED
+SRVKP-11096 `To Do` → `Dev Complete` ✅ APPLIED
   • tektoncd/results#1257: Change all occurences of GCS buckets...
   • tektoncd/cli#2768: Change all occurences of GCS buckets...
 
@@ -311,10 +311,10 @@ SRVKP-11090 `To Do` → `Code Review` ✅ APPLIED
 If a direct transition isn't available, jirasync will attempt to navigate through intermediate states automatically:
 
 ```
-Example: To Do → On QA (no direct path)
+Example: To Do → Dev Complete (no direct path)
 Step 1: To Do → In Progress
 Step 2: In Progress → Code Review
-Step 3: Code Review → On QA
+Step 3: Code Review → Dev Complete
 ```
 
 The algorithm prefers common workflow states like "In Progress" and "Code Review" as intermediate steps.
@@ -374,8 +374,8 @@ Starting jirasync for 2 repositories
 Found 4 unique tickets across all repositories
 
   ✓ Transitioned PROJ-123: 'To Do' → 'Code Review' (PR state: approved)
-  ✓ Transitioned PROJ-456: 'In Progress' → 'On QA' in 2 steps (PR state: merged)
-    Path: 'Code Review' → 'On QA'
+  ✓ Transitioned PROJ-456: 'In Progress' → 'Dev Complete' in 2 steps (PR state: merged)
+    Path: 'Code Review' → 'Dev Complete'
   ⊗ PROJ-789: Already in terminal state 'Closed' - skipping
 
 Jirasync completed - 2 tickets transitioned

--- a/cmd/jirasync/main.go
+++ b/cmd/jirasync/main.go
@@ -39,10 +39,10 @@ PR States → Jira Transitions:
   - draft/changes_requested → "In Progress"
   - ready/review_requested  → "Code Review"
   - approved                → "Code Review"
-  - merged                  → "On QA"
+  - merged                  → "Dev Complete"
   - closed (without merge)  → "In Progress"
 
-Note: Tickets are never automatically closed - "On QA" is the furthest state.
+Note: Tickets are never automatically closed - "Dev Complete" is the furthest state.
 Closing tickets should be done manually after QA verification.`,
 	RunE: runSync,
 }

--- a/internal/jirasync/path.go
+++ b/internal/jirasync/path.go
@@ -76,7 +76,7 @@ func TryMultiStepTransition(jiraClient *jira.Client, issueKey, currentStatus, ta
 		}
 
 		// No direct path - try progressing through workflow states
-		// Common workflow progression: To Do → In Progress → Code Review → On QA → Closed
+		// Common workflow progression: To Do → In Progress → Code Review → Dev Complete → Closed
 		preferredIntermediates := []string{
 			"In Progress", // From To Do
 			"Code Review", // From In Progress

--- a/internal/jirasync/transitions.go
+++ b/internal/jirasync/transitions.go
@@ -8,7 +8,7 @@ import (
 )
 
 // PRStateToJiraStatus maps PR states to desired Jira status
-// Note: We never automatically close tickets - "On QA" is the furthest we go
+// Note: We never automatically close tickets - "Dev Complete" is the furthest we go
 func PRStateToJiraStatus(prState github.PRState) string {
 	switch prState {
 	case github.PRStateDraft, github.PRStateChangesRequested:
@@ -18,7 +18,7 @@ func PRStateToJiraStatus(prState github.PRState) string {
 	case github.PRStateApproved:
 		return "Code Review"
 	case github.PRStateMerged:
-		return "On QA"
+		return "Dev Complete"
 	case github.PRStateClosed:
 		// Closed without merge goes back to In Progress (work abandoned/needs redo)
 		return "In Progress"

--- a/test/jirasync/README.md
+++ b/test/jirasync/README.md
@@ -96,10 +96,10 @@ Tickets with PRs across multiple repos: 2
   → [tektoncd/cli] PR #2768 (merged) - Change all occurences of GCS buckets with OCI buckets
   ⚠ PRs span 2 repositories
   Using most behind state: merged (from tektoncd/results PR #1257)
-  Target Jira Status: On QA
-  Available transitions (4): Start → In Progress, Review → Code Review, QA → On QA, Close → Closed
-  ⚠ No direct transition to 'On QA'
-  → Multi-step possible: 'To Do' → 'In Progress' → 'On QA'
+  Target Jira Status: Dev Complete
+  Available transitions (4): Start → In Progress, Review → Code Review, QA → Dev Complete, Close → Closed
+  ⚠ No direct transition to 'Dev Complete'
+  → Multi-step possible: 'To Do' → 'In Progress' → 'Dev Complete'
   ✓ Would attempt multi-step transition (max 3 steps)
 
 [SRVKP-11090] Replace occurences of GCS buckets to OCI buckets i...
@@ -110,7 +110,7 @@ Tickets with PRs across multiple repos: 2
   ⚠ PRs span 2 repositories
   Using most behind state: approved (from tektoncd/plumbing PR #3223)
   Target Jira Status: Code Review
-  Available transitions (4): Start → In Progress, Review → Code Review, QA → On QA, Close → Closed
+  Available transitions (4): Start → In Progress, Review → Code Review, QA → Dev Complete, Close → Closed
   ✓ Would execute direct transition: 'To Do' → 'Code Review'
   → Using transition: 'Review' (ID: 21)
 
@@ -198,13 +198,13 @@ PROJ-123 has PRs in 3 repos:
 When direct transition isn't available:
 
 ```
-Ticket in "To Do" → Target "On QA"
+Ticket in "To Do" → Target "Dev Complete"
 No direct path available
 
 Attempting multi-step:
   Step 1: To Do → In Progress
   Step 2: In Progress → Code Review
-  Step 3: Code Review → On QA
+  Step 3: Code Review → Dev Complete
 ```
 
 ### Terminal State Protection


### PR DESCRIPTION
Replace "On QA" with "Dev Complete" as the terminal automated Jira status for merged PRs, reflecting
the actual workflow where QA is a separate step.