### PR TITLE
feat(jirasync): add configurable final states

### DIFF
--- a/cmd/jirasync/main.go
+++ b/cmd/jirasync/main.go
@@ -27,6 +27,7 @@ var (
 	since                       string
 	slackWebhook                string
 	transitionComment           bool
+	finalStates                 []string
 )
 
 var rootCmd = &cobra.Command{
@@ -43,7 +44,10 @@ PR States → Jira Transitions:
   - closed (without merge)  → "In Progress"
 
 Note: Tickets are never automatically closed - "Dev Complete" is the furthest state.
-Closing tickets should be done manually after QA verification.`,
+Closing tickets should be done manually after QA verification.
+
+Tickets in "final states" (default: Closed, Done) are never transitioned.
+Use --final-states or the config file's final_states field to customize.`,
 	RunE: runSync,
 }
 
@@ -62,6 +66,9 @@ func init() {
 	rootCmd.Flags().StringVar(&since, "since", "", "Only process PRs updated since this date (format: 2006-01-02 or DD/MM/YYYY). Defaults to yesterday if not provided.")
 	rootCmd.Flags().StringVar(&slackWebhook, "slack-webhook", "", "Slack webhook URL for notifications (optional)")
 	rootCmd.Flags().BoolVar(&transitionComment, "transition-comment", false, "Add a Jira comment on each transitioned ticket explaining the reason (optional)")
+	rootCmd.Flags().StringSliceVar(&finalStates, "final-states", nil,
+		"Comma-separated Jira statuses that should not be transitioned (e.g., 'Closed,Done,On QA'). "+
+			"Overrides config file. Defaults to 'Closed,Done' if neither flag nor config is set.")
 
 	rootCmd.MarkFlagRequired("config")
 	rootCmd.MarkFlagRequired("github-token")
@@ -79,6 +86,18 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Loaded %d repositories from config\n", len(cfg.Repositories))
+
+	// Determine final states: CLI flag overrides config file; NewSyncer applies defaults if both empty
+	effectiveFinalStates := finalStates
+	if len(effectiveFinalStates) == 0 {
+		effectiveFinalStates = cfg.FinalStates
+	}
+
+	if len(effectiveFinalStates) > 0 {
+		fmt.Printf("Final states (will not transition): %v\n", effectiveFinalStates)
+	} else {
+		fmt.Printf("Final states (default): [Closed, Done]\n")
+	}
 
 	// Parse since date - default to yesterday if not provided
 	var sinceTime time.Time
@@ -109,6 +128,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		geminiModel,
 		sinceTime,
 		transitionComment,
+		effectiveFinalStates,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create syncer: %w", err)

--- a/internal/jirasync/config.go
+++ b/internal/jirasync/config.go
@@ -13,6 +13,7 @@ import (
 type Config struct {
 	Repositories []Repository `yaml:"repositories"`
 	Users        []string     `yaml:"users"`
+	FinalStates  []string     `yaml:"final_states"`
 }
 
 // Repository represents a GitHub repository to monitor

--- a/internal/jirasync/syncer.go
+++ b/internal/jirasync/syncer.go
@@ -28,6 +28,7 @@ type Syncer struct {
 	geminiClient                *gemini.Client
 	sinceTime                   time.Time
 	transitionComment           bool
+	finalStates                 map[string]bool
 }
 
 // SyncResult contains the results of syncing a repository
@@ -48,7 +49,7 @@ type SyncSummary struct {
 }
 
 // NewSyncer creates a new syncer instance
-func NewSyncer(githubToken, jiraURL, jiraEmail, jiraToken, jiraPRField, jiraReleaseNotesTextField, jiraReleaseNotesTypeField, jiraReleaseNotesStatusField, geminiAPIKey, geminiModel string, sinceTime time.Time, transitionComment bool) (*Syncer, error) {
+func NewSyncer(githubToken, jiraURL, jiraEmail, jiraToken, jiraPRField, jiraReleaseNotesTextField, jiraReleaseNotesTypeField, jiraReleaseNotesStatusField, geminiAPIKey, geminiModel string, sinceTime time.Time, transitionComment bool, finalStates []string) (*Syncer, error) {
 	jiraClient, err := jira.NewClient(jiraURL, jiraEmail, jiraToken, jiraPRField, jiraReleaseNotesTextField, jiraReleaseNotesTypeField, jiraReleaseNotesStatusField)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Jira client: %w", err)
@@ -60,6 +61,15 @@ func NewSyncer(githubToken, jiraURL, jiraEmail, jiraToken, jiraPRField, jiraRele
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Gemini client: %w", err)
 		}
+	}
+
+	// Build final-states lookup set; apply defaults when nothing is configured
+	fsMap := make(map[string]bool)
+	if len(finalStates) == 0 {
+		finalStates = []string{"Closed", "Done"}
+	}
+	for _, s := range finalStates {
+		fsMap[s] = true
 	}
 
 	return &Syncer{
@@ -75,6 +85,7 @@ func NewSyncer(githubToken, jiraURL, jiraEmail, jiraToken, jiraPRField, jiraRele
 		geminiClient:                geminiClient,
 		sinceTime:                   sinceTime,
 		transitionComment:           transitionComment,
+		finalStates:                 fsMap,
 	}, nil
 }
 
@@ -240,9 +251,9 @@ func (s *Syncer) SyncAll(ctx context.Context, repositories []Repository, users [
 
 		fmt.Printf("Processing %s (current: '%s')\n", issueKey, info.Status)
 
-		// Skip tickets in terminal states
-		if info.Status == "Closed" || info.Status == "Done" {
-			fmt.Printf("  ⊗ Already in terminal state '%s' - skipping\n", info.Status)
+		// Skip tickets in configured final states
+		if s.finalStates[info.Status] {
+			fmt.Printf("  ⊗ Already in final state '%s' - skipping\n", info.Status)
 			continue
 		}
 		// Find the most behind PR across all repos

--- a/jirasync-repos.yaml
+++ b/jirasync-repos.yaml
@@ -52,7 +52,7 @@ users:
   - divyansh42
   - enarha
   - infernus01
-  - jayesh-garg 
+  - jayesh-garg
   - jkhelil
   - khrm
   - manthinasai
@@ -66,3 +66,11 @@ users:
   - vdemeester
   - waveywaves
   - zakisk
+
+# Final states - tickets in these states will NOT be transitioned by jirasync.
+# If omitted, defaults to: Closed, Done
+final_states:
+  - Closed
+  - Done
+  - On QA
+  - Release Pending

--- a/test/jirasync/main.go
+++ b/test/jirasync/main.go
@@ -54,6 +54,7 @@ func main() {
 	// Parse arguments
 	var repos []jirasync.Repository
 	var configuredUsers []string
+	var configuredFinalStates []string
 
 	if len(os.Args) == 1 {
 		// No args - use default
@@ -74,6 +75,7 @@ func main() {
 		}
 		repos = cfg.Repositories
 		configuredUsers = cfg.Users
+		configuredFinalStates = cfg.FinalStates
 	} else if len(os.Args) >= 3 {
 		// Single repo mode
 		repos = []jirasync.Repository{
@@ -102,6 +104,16 @@ func main() {
 	if len(allowedUsers) > 0 {
 		fmt.Printf("Filtering PRs to %d configured users\n", len(allowedUsers))
 	}
+
+	// Build final states lookup set from config (or defaults)
+	if len(configuredFinalStates) == 0 {
+		configuredFinalStates = []string{"Closed", "Done"}
+	}
+	finalStatesMap := make(map[string]bool, len(configuredFinalStates))
+	for _, s := range configuredFinalStates {
+		finalStatesMap[s] = true
+	}
+	fmt.Printf("Final states (will not transition): %v\n", configuredFinalStates)
 
 	// Step 3: Connect to Jira
 	fmt.Println("=== Step 1: Connecting to Jira ===")
@@ -259,9 +271,9 @@ func main() {
 		fmt.Printf("[%s] %s\n", issueKey, info.Summary)
 		fmt.Printf("  Current Status: %s\n", info.Status)
 
-		// Skip tickets that are already closed
-		if info.Status == "Closed" || info.Status == "Done" {
-			fmt.Printf("  ⊗ Ticket is in terminal state - skipping\n\n")
+		// Skip tickets in configured final states
+		if finalStatesMap[info.Status] {
+			fmt.Printf("  ⊗ Ticket is in final state '%s' - skipping\n\n", info.Status)
 			continue
 		}
 


### PR DESCRIPTION
Replace hardcoded "Closed"/"Done" terminal state checks with a configurable final_states list. States can be set via the config file (final_states field) or overridden with the --final-states CLI flag. Defaults to
["Closed", "Done"] when neither is provided.

Fixes #18