### PR TITLE
feat(jirasync): skip release notes when type is "not required"

### DIFF
--- a/docs/RELEASE_NOTES_DESIGN.md
+++ b/docs/RELEASE_NOTES_DESIGN.md
@@ -56,6 +56,7 @@ Automatically extracts or AI-generates release notes from merged PRs and adds th
 10. **Large diffs**: Truncates to 3000 chars (description: 2000 chars)
 11. **No Gemini key**: Only extraction works, feature disabled if no notes found
 12. **Duplicate runs**: Currently adds new comment each time (TODO: dedup)
+13. **Release Notes not Required**: Tickets with Release Note Type set to "Release Notes not Required" are skipped entirely — no comment, no field update
 
 ## Usage
 
@@ -116,9 +117,12 @@ repositories:
 PR Sync → Get PRs → For each PR:
   ├─ Find Jira tickets (JQL)
   ├─ If PR is merged AND Gemini configured:
-  │   ├─ Try extract → Found? → Blue panel
-  │   └─ Not found? → AI generate (fetch diff/commits) → Get assignee → Orange panel + @mention
-  └─ Add comment to Jira (ADF)
+  │   ├─ For each ticket:
+  │   │   ├─ Check Release Note Type → "not Required"? → Skip
+  │   │   ├─ Try extract → Found? → Blue panel
+  │   │   └─ Not found? → AI generate → Get assignee → Orange panel + @mention
+  │   └─ Add comment to Jira (ADF)
+  └─ Otherwise skip release notes
 ```
 
 ## ADF Format

--- a/docs/RELEASE_NOTES_DESIGN.md
+++ b/docs/RELEASE_NOTES_DESIGN.md
@@ -118,7 +118,7 @@ PR Sync → Get PRs → For each PR:
   ├─ Find Jira tickets (JQL)
   ├─ If PR is merged AND Gemini configured:
   │   ├─ For each ticket:
-  │   │   ├─ Check Release Note Type → "not Required"? → Skip
+  │   │   ├─ Check Release Note Type → "Release Notes not Required"? → Skip
   │   │   ├─ Try extract → Found? → Blue panel
   │   │   └─ Not found? → AI generate → Get assignee → Orange panel + @mention
   │   └─ Add comment to Jira (ADF)

--- a/internal/jirasync/syncer.go
+++ b/internal/jirasync/syncer.go
@@ -460,21 +460,35 @@ func (s *Syncer) addReleaseNotes(ctx context.Context, pr *gogithub.PullRequest, 
 	for _, issue := range issues {
 		fmt.Printf("      → Processing %s...\n", issue.Key)
 
+		// Check if release notes are not required for this ticket
+		fullIssue, skipRN, err := s.checkReleaseNotesType(issue.Key)
+		if err != nil {
+			fmt.Printf("         ⚠ Failed to check release notes type: %v (continuing anyway)\n", err)
+		}
+		if skipRN {
+			fmt.Printf("         ⓘ Skipping: Release Note Type is 'Release Notes not Required'\n")
+			continue
+		}
+
 		if result.IsGenerated {
 			// AI-generated: Add orange warning panel with assignee mention
 			fmt.Printf("         Approach: Add AI-generated comment with assignee mention\n")
 
-			// Get assignee account ID
-			fullIssue, err := s.jiraClient.GetIssueWithFields(issue.Key, []string{"assignee"})
-			if err != nil {
-				fmt.Printf("         ⚠ Failed to get assignee: %v\n", err)
-				// Fall back to comment without mention
-				if err := s.jiraClient.AddReleaseNotesComment(issue.Key, result.Notes, result.Kind, releaseNotesStatus, ""); err != nil {
-					fmt.Printf("         ✗ Failed to add comment: %v\n", err)
-				} else {
-					fmt.Printf("         ✓ Added AI-generated comment (no assignee mention)\n")
+			// Reuse the issue fetched by checkReleaseNotesType (which already
+			// includes the assignee field), falling back to a dedicated fetch
+			// when the type-field check was not configured.
+			if fullIssue == nil {
+				fullIssue, err = s.jiraClient.GetIssueWithFields(issue.Key, []string{"assignee"})
+				if err != nil {
+					fmt.Printf("         ⚠ Failed to get assignee: %v\n", err)
+					// Fall back to comment without mention
+					if err := s.jiraClient.AddReleaseNotesComment(issue.Key, result.Notes, result.Kind, releaseNotesStatus, ""); err != nil {
+						fmt.Printf("         ✗ Failed to add comment: %v\n", err)
+					} else {
+						fmt.Printf("         ✓ Added AI-generated comment (no assignee mention)\n")
+					}
+					continue
 				}
-				continue
 			}
 
 			// Extract assignee account ID
@@ -529,6 +543,36 @@ func (s *Syncer) addReleaseNotes(ctx context.Context, pr *gogithub.PullRequest, 
 			}
 		}
 	}
+}
+
+// shouldSkipReleaseNotes checks whether a ticket's Release Note Type field
+// indicates that release notes are not required.
+func shouldSkipReleaseNotes(fields map[string]interface{}, typeFieldID string) bool {
+	if typeFieldID == "" {
+		return false
+	}
+	if typeField, ok := fields[typeFieldID].(map[string]interface{}); ok {
+		if value, ok := typeField["value"].(string); ok {
+			return value == "Release Notes not Required"
+		}
+	}
+	return false
+}
+
+// checkReleaseNotesType fetches the Release Note Type field for a ticket
+// and returns the full issue, whether to skip release notes, and any error.
+// When the type field is not configured, it returns (nil, false, nil).
+func (s *Syncer) checkReleaseNotesType(issueKey string) (*jira.Issue, bool, error) {
+	if s.jiraReleaseNotesTypeField == "" {
+		return nil, false, nil
+	}
+
+	fullIssue, err := s.jiraClient.GetIssueWithFields(issueKey, []string{s.jiraReleaseNotesTypeField, "assignee"})
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to fetch release notes type: %w", err)
+	}
+
+	return fullIssue, shouldSkipReleaseNotes(fullIssue.Fields, s.jiraReleaseNotesTypeField), nil
 }
 
 // prStateReason returns a human-readable explanation for why a PR's state triggers a Jira transition

--- a/internal/jirasync/syncer.go
+++ b/internal/jirasync/syncer.go
@@ -466,7 +466,7 @@ func (s *Syncer) addReleaseNotes(ctx context.Context, pr *gogithub.PullRequest, 
 			fmt.Printf("         ⚠ Failed to check release notes type: %v (continuing anyway)\n", err)
 		}
 		if skipRN {
-			fmt.Printf("         ⓘ Skipping: Release Note Type is 'Release Notes not Required'\n")
+			fmt.Printf("         ⓘ Skipping: Release Note Type is '%s'\n", releaseNotesNotRequired)
 			continue
 		}
 
@@ -545,6 +545,10 @@ func (s *Syncer) addReleaseNotes(ctx context.Context, pr *gogithub.PullRequest, 
 	}
 }
 
+// releaseNotesNotRequired is the Jira "Release Note Type" dropdown value that
+// indicates no release notes are needed for a ticket.
+const releaseNotesNotRequired = "Release Notes not Required"
+
 // shouldSkipReleaseNotes checks whether a ticket's Release Note Type field
 // indicates that release notes are not required.
 func shouldSkipReleaseNotes(fields map[string]interface{}, typeFieldID string) bool {
@@ -553,7 +557,7 @@ func shouldSkipReleaseNotes(fields map[string]interface{}, typeFieldID string) b
 	}
 	if typeField, ok := fields[typeFieldID].(map[string]interface{}); ok {
 		if value, ok := typeField["value"].(string); ok {
-			return value == "Release Notes not Required"
+			return value == releaseNotesNotRequired
 		}
 	}
 	return false

--- a/internal/jirasync/syncer_test.go
+++ b/internal/jirasync/syncer_test.go
@@ -11,13 +11,13 @@ func TestShouldSkipReleaseNotes(t *testing.T) {
 	}{
 		{
 			name:        "type field not configured",
-			fields:      map[string]interface{}{"cf_10785": map[string]interface{}{"value": "Release Notes not Required"}},
+			fields:      map[string]interface{}{"cf_10785": map[string]interface{}{"value": releaseNotesNotRequired}},
 			typeFieldID: "",
 			want:        false,
 		},
 		{
 			name:        "release notes not required",
-			fields:      map[string]interface{}{"cf_10785": map[string]interface{}{"value": "Release Notes not Required"}},
+			fields:      map[string]interface{}{"cf_10785": map[string]interface{}{"value": releaseNotesNotRequired}},
 			typeFieldID: "cf_10785",
 			want:        true,
 		},

--- a/internal/jirasync/syncer_test.go
+++ b/internal/jirasync/syncer_test.go
@@ -1,0 +1,70 @@
+package jirasync
+
+import "testing"
+
+func TestShouldSkipReleaseNotes(t *testing.T) {
+	tests := []struct {
+		name        string
+		fields      map[string]interface{}
+		typeFieldID string
+		want        bool
+	}{
+		{
+			name:        "type field not configured",
+			fields:      map[string]interface{}{"cf_10785": map[string]interface{}{"value": "Release Notes not Required"}},
+			typeFieldID: "",
+			want:        false,
+		},
+		{
+			name:        "release notes not required",
+			fields:      map[string]interface{}{"cf_10785": map[string]interface{}{"value": "Release Notes not Required"}},
+			typeFieldID: "cf_10785",
+			want:        true,
+		},
+		{
+			name:        "release notes required",
+			fields:      map[string]interface{}{"cf_10785": map[string]interface{}{"value": "Release Notes Required"}},
+			typeFieldID: "cf_10785",
+			want:        false,
+		},
+		{
+			name:        "type field is nil",
+			fields:      map[string]interface{}{"cf_10785": nil},
+			typeFieldID: "cf_10785",
+			want:        false,
+		},
+		{
+			name:        "type field is wrong shape (string instead of map)",
+			fields:      map[string]interface{}{"cf_10785": "some string"},
+			typeFieldID: "cf_10785",
+			want:        false,
+		},
+		{
+			name:        "type field map has no value key",
+			fields:      map[string]interface{}{"cf_10785": map[string]interface{}{"id": "123"}},
+			typeFieldID: "cf_10785",
+			want:        false,
+		},
+		{
+			name:        "type field not present in fields map",
+			fields:      map[string]interface{}{},
+			typeFieldID: "cf_10785",
+			want:        false,
+		},
+		{
+			name:        "nil fields map",
+			fields:      nil,
+			typeFieldID: "cf_10785",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldSkipReleaseNotes(tt.fields, tt.typeFieldID)
+			if got != tt.want {
+				t.Errorf("shouldSkipReleaseNotes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Skip all release note operations (Jira field updates and comment additions) when a
ticket's `Release Note Type` field is already set to `"Release Notes not Required"`.
Previously, the tool would generate or extract release notes and post them regardless
of this opt-out signal, creating unnecessary noise on tickets that had been explicitly
marked as not needing release notes.

Fixes #17

## Changes

A new `shouldSkipReleaseNotes` pure function checks the Release Note Type field value
against the opt-out string. A `checkReleaseNotesType` method wraps it with the Jira API
call, fetching both the type field and the assignee in a single request. This check
runs at the top of the per-ticket loop in `addReleaseNotes` — when the type matches,
the ticket is skipped with a log message and neither the extracted-from-PR path nor the
AI-generated path executes.

As a side-effect, the prefetched assignee eliminates a second API round-trip for
AI-generated notes on non-skipped tickets when the type field is configured.

Table-driven unit tests cover all edge cases: field not configured, exact match,
different value, nil field, wrong field shape, missing value key, missing field,
and nil fields map.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./internal/jirasync/...` — 8/8 tests pass
- [ ] Manual: run against a Jira ticket with Release Note Type = "Release Notes not Required" and verify no comment is added
- [ ] Manual: run against a ticket with a different type value and verify release notes are still processed

## Notes

- The opt-out value is an exact case-sensitive match against `"Release Notes not Required"` — this matches the Jira dropdown option verbatim.
- When `--jira-release-notes-type-field` is not passed (empty), the feature is a complete no-op.
- Errors from the type-field check are logged as warnings and do not block processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)